### PR TITLE
Fixed tag referring to article

### DIFF
--- a/lib/convertFromUrl.js
+++ b/lib/convertFromUrl.js
@@ -18,7 +18,7 @@ function convertFromUrl(url) {
         return reject(err);
 
       let $ = cheerio.load(body);
-      let html = $('.postArticle-content').html() || '';
+      let html = $('article').html() || '';
       let markdown = toMarkdown(html, { gfm: true, converters: converters });
 
       resolve(markdown);


### PR DESCRIPTION
Medium posts now refer to the content of the article by the `<article>` tag. This is a simple fix to extract the article content as using `.postArticle-content` no longer finds the content. 