### PR TITLE
Added Bin to package.json [https://docs.npmjs.com/files/package.json#bin]

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.3",
   "description": "import a medium URL and convert it to markdown",
   "main": "index.js",
+  "bin": "./index.js",
   "scripts": {
     "convert": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
A lot of packages have one or more executable files that they’d like to install into the PATH. npm makes this pretty easy (in fact, it uses this feature to install the “npm” executable.)

To use this, supply a bin field in your package.json which is a map of command name to local file name. On install, npm will symlink that file into prefix/bin for global installs, or ./node_modules/.bin/ for local installs.

[https://docs.npmjs.com/files/package.json#bin](https://docs.npmjs.com/files/package.json#bin)